### PR TITLE
dev: Remove settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "ocaml.sandbox": {
-        "kind": "opam",
-        "switch": "${workspaceFolder:creusot-ide}"
-    }
-}


### PR DESCRIPTION
I just use my global switch and my directory isn't named creusot-ide (too long). I wonder if there is a way to have a repo-specific settings.json together with a user-specific one.