### PR TITLE
Add commands to show tasks (proof context)

### DIFF
--- a/server/lib/util.ml
+++ b/server/lib/util.ml
@@ -79,3 +79,11 @@ let split_first c s =
 let split_last c s =
   let i = String.rindex s c in
   (String.sub s 0 i, String.sub s (i + 1) (String.length s - i - 1))
+
+let drop_prefix ~prefix str =
+  if String.starts_with ~prefix str then String.sub str (String.length prefix) (String.length str - String.length prefix)
+  else str
+
+let drop_suffix ~suffix str =
+  if String.ends_with ~suffix str then String.sub str 0 (String.length str - String.length suffix)
+  else str

--- a/server/lib/util.mli
+++ b/server/lib/util.mli
@@ -22,3 +22,5 @@ end
 val walk_dir : ?exclude:string list -> string -> string list
 val split_first : char -> string -> string * string
 val split_last : char -> string -> string * string
+val drop_prefix : prefix:string -> string -> string
+val drop_suffix : suffix:string -> string -> string

--- a/server/lib/why3findUtil.mli
+++ b/server/lib/why3findUtil.mli
@@ -73,3 +73,10 @@ val get_test_items : rust_file:string -> Test_api.test_item list
 val refresh_info : rust_file:string -> unit
 val add_coma2 : string -> unit
 val get_rust_source : coma_file:string -> string option
+
+(** [decode_subgoal (uri_to_string (DocumentUri.of_string (encode_subgoal x))) = x]
+   where [uri_to_string] happens in typescript via the [toString()] method
+   (does not percent-decode, so we have to do it in [decode_subgoal]) *)
+val encode_subgoal : ProofPath.qualified_goal -> string
+(** Throws Failure *)
+val decode_subgoal : string -> ProofPath.qualified_goal

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -205,27 +205,14 @@ export function activate(context: ExtensionContext) {
   /* Virtual document to show Why3 proof context */
   const why3Scheme = 'why3';
   const why3DocProvider = new class implements vscode.TextDocumentContentProvider {
+    // TODO: emit onDidChange events when proofs change
     onDidChangeEmitter = new vscode.EventEmitter<Uri>();
     onDidChange = this.onDidChangeEmitter.event;
-    content = "";
-    newText(newContent) {
-      this.content = newContent;
-    }
-    provideTextDocumentContent(uri: Uri): string {
-      return this.content;
+    provideTextDocumentContent(uri: Uri): Thenable<string> {
+      return client.sendRequest("creusot/showTask", uri.toString());
     }
   }
   context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(why3Scheme, why3DocProvider));
-  const virtualFileName = "Task";
-  const uri = vscode.Uri.parse('why3:' + virtualFileName);
-  registerCommand(context, "creusot.showTask", async (arg) => {
-    const msg = client.sendRequest("creusot/show", arg);
-    why3DocProvider.newText(msg);
-    why3DocProvider.onDidChangeEmitter.fire(uri);
-    const doc = await vscode.workspace.openTextDocument(uri);
-    vscode.languages.setTextDocumentLanguage(doc, "coma");
-    await vscode.window.showTextDocument(doc, { preview: false });
-  });
 
   createTests(client);
 


### PR DESCRIPTION
In code lenses for whole functions and in diagnostic messages for ensures/proof_assert/invariant, there are now links to display the associated tasks.