### PR TITLE
Isolate Why3 interaction into its own process

### DIFF
--- a/server/lib/creusot_manager.ml
+++ b/server/lib/creusot_manager.ml
@@ -552,7 +552,7 @@ let guess_language path =
   else if basename path = "proof.json" then ProofJson
   else Unknown
 
-let add_file src =
+let add_file ~get_proof_info src =
   let path = file_name_of_source src in
   match guess_language path with
   | Rust ->
@@ -566,7 +566,7 @@ let add_file src =
       add_orphan_proof_json (File proof);
       add_rust_file src
     ) else (
-      Why3findUtil.refresh_info ~rust_file:path;
+      Why3findUtil.refresh_info ~get_proof_info ~rust_file:path;
       add_rust_file src
     )
   | Coma -> add_coma_file src; add_coma2 (file_name_of_source src)
@@ -593,8 +593,8 @@ let uri_to_file uri =
   else if Filename.basename path = "proof.json" then Some (ProofJson path)
   else None
 
-let refresh = function
-  | Rust rust_file -> Why3findUtil.refresh_info ~rust_file
+let refresh ~get_proof_info = function
+  | Rust rust_file -> Why3findUtil.refresh_info ~get_proof_info ~rust_file
   | _ -> ()
 
 let get_code_lenses = function

--- a/server/lib/creusot_manager.mli
+++ b/server/lib/creusot_manager.mli
@@ -55,12 +55,12 @@ val is_orphan : string -> bool
 val initialize : string -> unit
 
 val get_revdep : DocumentUri.t -> DocumentUri.t option
-val add_file : source -> unit
+val add_file : get_proof_info:(proof_file:string -> Why3findUtil.ProofInfo.t option) -> source -> unit
 
 type file_id
 
 val uri_to_file : DocumentUri.t -> file_id option
-val refresh : file_id -> unit
+val refresh : get_proof_info:(proof_file:string -> Why3findUtil.ProofInfo.t option) -> file_id -> unit
 val get_code_lenses : file_id -> CodeLens.t list
 val get_diagnostics : file_id -> Diagnostic.t list option
 val get_test_items : file_id -> Test_api.test_item list option

--- a/server/lib/why3findUtil.mli
+++ b/server/lib/why3findUtil.mli
@@ -63,14 +63,17 @@ module ProofInfo : sig
     unproved_goals: goal list;
   }
   val pp_info : Format.formatter -> t -> unit
+  val to_file : string -> t -> unit
+  val of_file : string -> t option
 end
   
 val get_proof_info : Why3find.Project.env -> proof_file:string -> coma_file:string -> ProofInfo.t
 val create_proof_info : Why3find.Project.env -> proof_file:string -> coma_file:string -> unit
+val register_proof_info : coma_file:string -> ProofInfo.t option -> unit
 val get_diagnostics : rust_file:string -> Diagnostic.t list
 val get_lenses : rust_file:string -> CodeLens.t list
 val get_test_items : rust_file:string -> Test_api.test_item list
-val refresh_info : rust_file:string -> unit
+val refresh_info : get_proof_info:(proof_file:string -> ProofInfo.t option) -> rust_file:string -> unit
 val add_coma2 : string -> unit
 val get_rust_source : coma_file:string -> string option
 

--- a/server/lib/why3findUtil.mli
+++ b/server/lib/why3findUtil.mli
@@ -54,6 +54,7 @@ module ProofInfo : sig
   }
   type t = {
     coma_file: string;
+    coma_file_hash: string;
     proof_file: string;
     rust_file: string;
 
@@ -64,7 +65,7 @@ module ProofInfo : sig
   }
   val pp_info : Format.formatter -> t -> unit
   val to_file : string -> t -> unit
-  val of_file : string -> t option
+  val of_file : string -> t
 end
   
 val get_proof_info : Why3find.Project.env -> proof_file:string -> coma_file:string -> ProofInfo.t


### PR DESCRIPTION
Fix #46. Mitigate space leaks in the Why3 API by only using it in short-lived processes.