### PR TITLE
Update to latest version of Creusot

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1763511871,
-        "narHash": "sha256-KKZWi+ij7oT0Ag8yC6MQkzfHGcytyjMJDD+47ZV1YNU=",
+        "lastModified": 1773189535,
+        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "099f9014bc8d0cd6e445470ea1df0fd691d5a548",
+        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
         "type": "github"
       },
       "original": {
@@ -23,16 +23,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1768035092,
-        "narHash": "sha256-YlRRCOM0q1vXFAMFaZwU1TjV2TNSYHTnCz124mBxETA=",
+        "lastModified": 1776685811,
+        "narHash": "sha256-UDXNCMn8RGYs5NznbGcBZfTHpcCyssg1mk2NVNjctl0=",
         "owner": "creusot-rs",
         "repo": "creusot",
-        "rev": "fd089be0e96442f5e71605fbb129e6d6f7b264f3",
+        "rev": "2640af77e4cf3686b428b5b252d7909ac1f48847",
         "type": "github"
       },
       "original": {
         "owner": "creusot-rs",
-        "ref": "v0.9.0",
+        "ref": "v0.11.0",
         "repo": "creusot",
         "type": "github"
       }
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764020296,
-        "narHash": "sha256-6zddwDs2n+n01l+1TG6PlyokDdXzu/oBmEejcH5L5+A=",
+        "lastModified": 1773068389,
+        "narHash": "sha256-vMrm7Pk2hjBRPnCSjhq1pH0bg350Z+pXhqZ9ICiqqCs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a320ce8e6e2cc6b4397eef214d202a50a4583829",
+        "rev": "44bae273f9f82d480273bab26f5c50de3724f52f",
         "type": "github"
       },
       "original": {
@@ -91,11 +91,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764211126,
-        "narHash": "sha256-p5y13PnMZYd5WdHk+XCzyUaLGBUCwnz2n4KYKEZM0Pw=",
+        "lastModified": 1773216618,
+        "narHash": "sha256-iZlowevS+xKLGOXtZwpIrz3SWe7PtoGUfEeVZNib+WE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "895935bff08cfcfb663fb9c8263c43596e7cd1ed",
+        "rev": "07d7dc6fcc5eae76b4fb0e19d4afd939437bec97",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -18,40 +18,39 @@
     "creusot": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1776685811,
-        "narHash": "sha256-UDXNCMn8RGYs5NznbGcBZfTHpcCyssg1mk2NVNjctl0=",
+        "lastModified": 1778773766,
+        "narHash": "sha256-tDvTQu/cpMttY35bhGrm3zjrMWU7TjSYrkdUq/JgHNQ=",
         "owner": "creusot-rs",
         "repo": "creusot",
-        "rev": "2640af77e4cf3686b428b5b252d7909ac1f48847",
+        "rev": "1fd2bc677f497896c65c637e81e56e808f781d31",
         "type": "github"
       },
       "original": {
         "owner": "creusot-rs",
-        "ref": "v0.11.0",
         "repo": "creusot",
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -70,12 +69,27 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "creusot": "creusot",
-        "flake-utils": [
+        "flake-parts": [
           "creusot",
-          "flake-utils"
+          "flake-parts"
         ],
         "nixpkgs": [
           "creusot",
@@ -91,31 +105,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1773216618,
-        "narHash": "sha256-iZlowevS+xKLGOXtZwpIrz3SWe7PtoGUfEeVZNib+WE=",
+        "lastModified": 1777259803,
+        "narHash": "sha256-fIb/EoVu/1U0qVrE6qZCJ2WCfprRpywNIAVzKEACIQc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "07d7dc6fcc5eae76b4fb0e19d4afd939437bec97",
+        "rev": "a6cb2224d975e16b5e67de688c6ad306f7203425",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,72 +1,92 @@
 {
   inputs = {
     nixpkgs.follows = "creusot/nixpkgs";
-    flake-utils.follows = "creusot/flake-utils";
+    flake-parts.follows = "creusot/flake-parts";
 
-    creusot.url = "github:creusot-rs/creusot/v0.11.0";
+    creusot.url = "github:creusot-rs/creusot";
   };
 
-  outputs = {
-    self,
-    creusot,
-    flake-utils,
-    nixpkgs,
-  }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs {inherit system;};
-      pkgsCreusot = creusot.lib.${system}.pkgs;
+  outputs =
+    inputs@{
+      creusot,
+      flake-parts,
+      nixpkgs,
+      self,
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "aarch64-darwin"
+        "x86_64-linux"
+      ];
 
-      version = "0.2.594";
-    in {
-      packages = {
-        code = pkgs.buildNpmPackage {
-          inherit version;
+      perSystem =
+        {
+          pkgs,
+          system,
+          ...
+        }:
+        let
+          version = pkgs.creusot.creusot.version;
+        in
+        {
+          _module.args.pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ creusot.overlays.default ];
+          };
 
-          pname = "creusot-ide";
-          src = ./.;
-          npmDepsHash = "sha256-7bODwzezOOXmS43pezizOQ+1qfDD/8y23NVlDRvtpJY=";
+          formatter = pkgs.nixfmt-tree;
 
-          buildInputs = with pkgs; [libsecret];
-          nativeBuildInputs = with pkgs; [pkg-config];
+          packages = {
+            code = pkgs.buildNpmPackage {
+              inherit version;
 
-          prePatch = ''
-            sed -i -e 's/"0.1.1"/"${version}"/g' package.json package-lock.json
-          '';
+              pname = "creusot-ide";
+              src = ./.;
+              npmDepsHash = "sha256-8tB57OR3vBLdYk+cXRMwk/tQSDBurgH4uYwzz/j1Ncs=";
 
-          installPhase = ''
-            mkdir $out
-            npx vsce package -o $out/creusot-ide.vsix
-          '';
+              buildInputs = with pkgs; [ libsecret ];
+              nativeBuildInputs = with pkgs; [ pkg-config ];
+
+              prePatch = ''
+                sed -i -e 's/"0.1.1"/"${version}"/g' package.json package-lock.json
+              '';
+
+              installPhase = ''
+                mkdir $out
+                npx vsce package -o $out/creusot-ide.vsix
+              '';
+            };
+
+            lsp = pkgs.ocamlPackages.buildDunePackage {
+              inherit version;
+
+              pname = "creusot-lsp";
+              src = ./.;
+
+              nativeBuildInputs = [ pkgs.ocamlPackages.menhir ];
+              buildInputs =
+                (with pkgs.creusot; [
+                  why3
+                  why3find
+                ])
+                ++ (with pkgs.ocamlPackages; [
+                  dune-build-info
+                  dune-site
+                  jsonm
+                  linol-lwt
+                  logs
+                  lwt
+                  menhirLib
+                  ppx_deriving
+                  ppx_expect
+                  ppx_yojson_conv
+                  terminal_size
+                  toml
+                  uri
+                  xmlm
+                ]);
+            };
+          };
         };
-
-        lsp = pkgs.ocamlPackages.buildDunePackage {
-          inherit version;
-
-          pname = "creusot-lsp";
-          src = ./.;
-
-          nativeBuildInputs = [pkgs.ocamlPackages.menhir];
-          buildInputs =
-            (with pkgsCreusot; [why3 why3find])
-            ++ (with pkgs.ocamlPackages; [
-              dune-build-info
-              dune-site
-              jsonm
-              linol-lwt
-              logs
-              lwt
-              menhirLib
-              ppx_deriving
-              ppx_expect
-              ppx_yojson_conv
-              terminal_size
-              toml
-              uri
-              xmlm
-            ]);
-        };
-      };
-
-      formatter = pkgs.alejandra;
-    });
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.follows = "creusot/nixpkgs";
     flake-utils.follows = "creusot/flake-utils";
 
-    creusot.url = "github:creusot-rs/creusot/v0.9.0";
+    creusot.url = "github:creusot-rs/creusot/v0.11.0";
   };
 
   outputs = {
@@ -16,7 +16,7 @@
       pkgs = import nixpkgs {inherit system;};
       pkgsCreusot = creusot.lib.${system}.pkgs;
 
-      version = "0.1.99";
+      version = "0.2.594";
     in {
       packages = {
         code = pkgs.buildNpmPackage {
@@ -24,7 +24,7 @@
 
           pname = "creusot-ide";
           src = ./.;
-          npmDepsHash = "sha256-QHwVZByCru9HoRyf4T6fGVFDFwh9h9rikB61zxo2i7A=";
+          npmDepsHash = "sha256-7bODwzezOOXmS43pezizOQ+1qfDD/8y23NVlDRvtpJY=";
 
           buildInputs = with pkgs; [libsecret];
           nativeBuildInputs = with pkgs; [pkg-config];


### PR DESCRIPTION
The tag version is not explicitly stated in `inputs` because a breaking change has occurred (see https://github.com/creusot-rs/creusot/pull/2102).

Once a new tag is released, the following change can be made:
```diff
- creusot.url = "github:creusot-rs/creusot";
+ creusot.url = "github:creusot-rs/creusot/v0.12.0";
```